### PR TITLE
fixed misleading error message if iconv isn't installed

### DIFF
--- a/lib/html5lib/InputStream.php
+++ b/lib/html5lib/InputStream.php
@@ -76,7 +76,7 @@ class HTML5_InputStream {
             $data = @iconv('UTF-8', 'UTF-8//IGNORE', $data);
         } else {
             // we can make a conforming native implementation
-            throw new Exception('Not implemented, please install mbstring or iconv');
+            throw new Exception('Not implemented, please install iconv');
         }
 
         /* One leading U+FEFF BYTE ORDER MARK character must be


### PR DESCRIPTION
Since this library doesn't support `mbstring`, remove mention of it from the error message that's thrown if `iconv` isn't installed.
